### PR TITLE
Fix artifacts and peaky behavior of posterior

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ The executables use deal.II's `ParameterHandler` to read configuration from a JS
 - `output directory`: Path to the output directory for results
 - `output prefix`: Prefix for output filenames (e.g., 'run1_' or 'test_')
 - `adjoint data file`: Filename of the adjoint data npy file (assumed to be in the same directory as the input npy file, only used for adjoint problem)
+- `mollification sigma factor`: Factor to scale the mollification sigma for the adjoint problem's right-hand side (smoothing of the delta distributions at observation points)
 
 Example JSON configuration (`parameters.json`):
 ```json
@@ -46,6 +47,9 @@ Example JSON configuration (`parameters.json`):
     "output directory": "output",
     "output prefix": "my_sim_",
     "adjoint data file": "adjoint_data.npy"
+  },
+  "Adjoint": {
+    "mollification sigma factor": 1.0
   }
 }
 ```
@@ -63,6 +67,10 @@ subsection Input/Output
   set output directory = output
   set output prefix = 
   set adjoint data file = adjoint_data.npy
+end
+
+subsection Adjoint
+  set mollification sigma factor = 1.0
 end
 ```
 

--- a/darcy_adjoint.cc
+++ b/darcy_adjoint.cc
@@ -5,7 +5,7 @@
 #include "parameters.h"
 
 // Explicit template instantiation
-template class darcy::DarcyAdjoint<3>;
+template class darcy::DarcyAdjoint<2>;
 
 // ---------------------- main function adjoint -----------------------------
 int

--- a/darcy_adjoint.cc
+++ b/darcy_adjoint.cc
@@ -5,7 +5,7 @@
 #include "parameters.h"
 
 // Explicit template instantiation
-template class darcy::DarcyAdjoint<2>;
+template class darcy::DarcyAdjoint<3>;
 
 // ---------------------- main function adjoint -----------------------------
 int

--- a/darcy_forward.h
+++ b/darcy_forward.h
@@ -91,13 +91,15 @@ namespace darcy
         const types::global_cell_index cell_id =
           cell->global_active_cell_index();
 
-        // Extended bounding box for curved cells
+        // Extended bounding box for curved cells (quadratic mapping can
+        // cause cell geometry to extend significantly beyond vertex positions)
         BoundingBox<dim> bbox(cell->bounding_box());
         auto             bounds = bbox.get_boundary_points();
         for (unsigned int d = 0; d < dim; ++d)
           {
-            bounds.first[d] -= 0.1 * (bounds.second[d] - bounds.first[d]);
-            bounds.second[d] += 0.1 * (bounds.second[d] - bounds.first[d]);
+            const double extent = bounds.second[d] - bounds.first[d];
+            bounds.first[d] -= 0.5 * extent;
+            bounds.second[d] += 0.5 * extent;
           }
         bbox = BoundingBox<dim>(bounds);
 

--- a/parameters.h
+++ b/parameters.h
@@ -17,14 +17,21 @@ namespace darcy
   // ===========================================================================
   struct Parameters
   {
-    std::string  input_npy_file;
-    std::string  output_directory;
-    std::string  output_prefix;
-    std::string  adjoint_data_file;
+    // Discretization
     unsigned int fe_degree;
     unsigned int degree_rf;
     unsigned int refinement_level;
     unsigned int refinement_level_obs;
+
+    // Input/Output
+    std::string input_npy_file;
+    std::string output_directory;
+    std::string output_prefix;
+    std::string adjoint_data_file;
+
+    // Adjoint solver settings
+    double
+      mollification_sigma_factor; // Gaussian width = factor * avg cell diameter
 
     // Declare all parameters in the ParameterHandler
     static void
@@ -94,6 +101,18 @@ namespace darcy
         "directory as the input npy file, only used for adjoint problem)");
     }
     prm.leave_subsection();
+
+    prm.enter_subsection("Adjoint");
+    {
+      prm.declare_entry(
+        "mollification sigma factor",
+        "1.5",
+        Patterns::Double(0.1, 10.0),
+        "Width of Gaussian mollification kernel as multiple of average cell "
+        "diameter. Recommended: 1.0-3.0. Smaller values give sharper point "
+        "loads, larger values give smoother gradients.");
+    }
+    prm.leave_subsection();
   }
 
   void
@@ -114,6 +133,12 @@ namespace darcy
       output_directory  = prm.get("output directory");
       output_prefix     = prm.get("output prefix");
       adjoint_data_file = prm.get("adjoint data file");
+    }
+    prm.leave_subsection();
+
+    prm.enter_subsection("Adjoint");
+    {
+      mollification_sigma_factor = prm.get_double("mollification sigma factor");
     }
     prm.leave_subsection();
   }


### PR DESCRIPTION
## Description
This MR implements a Gaussian smoothing /smearing for the point-wise observables in the adjoint's rhs. The latter leads to instabilities, and slightly distributing the load via a Gaussian removed the artifacts while retaining the posterior's solution quality. We also refactored the sigma parameter, which controls the strength of the smoothing. A value of 1.0 seems to be a good working point. Note that we already implemented the smoothing as a function of the average element size, and sigma is just a scaling factor with respect to it.

## Interested parties
@bergbauer could you please have a look at the code and check the concept?