### PR TITLE
Replace mollified adjoint RHS with exact point-wise evaluation, imple…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,7 @@ input/
 # ignore Visual Studio Code settings
 .vscode
 
+# ignore Claude Code files
+CLAUDE.md
+.claude/
+

--- a/parameters_ground_truth.json
+++ b/parameters_ground_truth.json
@@ -1,0 +1,18 @@
+{
+  "Discretization": {
+    "pressure fe degree": 1,
+    "random field fe degree": 2,
+    "refinement level": 4,
+    "refinement level obs": 3
+  },
+  "Prior": {
+    "alpha": 1,
+    "kappa squared": 0.1
+  },
+  "Input/Output": {
+    "input npy file": "/home/nitzler/workspace/QUEENS_Rep/queens_output_3d_paper/lf_mean.npy",
+    "output directory": "/home/nitzler/workspace/Own_dealii_projects/darcy_flow_3d_donut/output/ground_truth/",
+    "output prefix": "new_",
+    "adjoint data file": "adjoint_data.npy"
+  }
+}

--- a/parameters_posterior.json
+++ b/parameters_posterior.json
@@ -1,0 +1,18 @@
+{
+  "Discretization": {
+    "pressure fe degree": 1,
+    "random field fe degree": 2,
+    "refinement level": 4,
+    "refinement level obs": 3
+  },
+  "Prior": {
+    "alpha": 1,
+    "kappa squared": 0.1
+  },
+  "Input/Output": {
+    "input npy file": "/home/nitzler/workspace/QUEENS_Rep/queens_output_3d_paper/lf_mean.npy",
+    "output directory": "/home/nitzler/workspace/Own_dealii_projects/darcy_flow_3d_donut/output",
+    "output prefix": "new_",
+    "adjoint data file": "adjoint_data.npy"
+  }
+}

--- a/parameters_template.json
+++ b/parameters_template.json
@@ -1,0 +1,18 @@
+{
+  "Discretization": {
+    "pressure fe degree": 1,
+    "random field fe degree": 2,
+    "refinement level": 4,
+    "refinement level obs": 3
+  },
+  "Prior": {
+    "alpha": 2,
+    "kappa squared": 16.0
+  },
+  "Input/Output": {
+    "input npy file": "{{ input_file_path }}",
+    "output directory": "{{ output_directory }}",
+    "output prefix": "{{ output_prefix }}",
+    "adjoint data file": "adjoint_data.npy"
+  }
+}

--- a/preconditioner.h
+++ b/preconditioner.h
@@ -61,12 +61,10 @@ namespace Preconditioner
     VectorType       &dst,
     const VectorType &src) const
   {
-    // Use ReductionControl for both absolute and relative tolerance
-    // This ensures consistent convergence regardless of src magnitude
-    const double         abs_tol = 1e-14;
-    const double         rel_tol = 1e-10;
-    ReductionControl     solver_control(src.size(), abs_tol, rel_tol);
-    SolverCG<VectorType> cg(solver_control);
+    // Use fixed iteration count instead of tight tolerance to limit
+    // per-application cost while maintaining preconditioner quality
+    IterationNumberControl solver_control(5, 1e-14);
+    SolverCG<VectorType>   cg(solver_control);
 
     dst = 0;
 


### PR DESCRIPTION
…ment SPDE-GMRF prior

- Replace Gaussian-mollified adjoint RHS assembly with exact point-wise evaluation using cached point-cell associations (adjoint of forward point evaluation operator)
- Implement SPDE--GMRF prior gradient with cascade decomposition for general operator power n (Matern smoothness nu = n - dim/2)
- Add configurable prior parameters: alpha (SPDE power) and kappa^2 (correlation length control via rho = sqrt(8*nu)/kappa)
- Use rtree spatial index for O(n log n) point location in both forward and adjoint solvers (replacing brute-force O(cells x points))
- Use fixed CG iteration count (5 iters) in Schur complement preconditioner instead of tight tolerance
- Add parameter JSON files for posterior, ground truth, and template
- Add Claude-related files to .gitignore