### PR TITLE
Optimize solver performance, simplify prior to Markov-only,

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,3 +23,4 @@ endfunction()
 
 setup_executable("darcy_forward")
 setup_executable("darcy_adjoint")
+setup_executable("export_sparsity")

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Isotropic Darcy flow
 
-This is a fully parallelized implementation of a Darcy flow PDE with a transverse isotropic permeability field, using deal.II. The governing equations that are solved read as follows:
+This is a fully parallelized implementation of a Darcy flow PDE with an isotropic permeability field on a 3D eccentric hyper-shell ("donut") geometry, using deal.II and Trilinos. The governing equations read:
 
 $$
 \begin{align*}
@@ -10,65 +10,58 @@ p &= g \quad \text{on } \partial\Omega
 \end{align*}
 $$
 
-With $K$ being a $\dim \times \dim$ permeability tensor, $\boldsymbol{u}$ the flow velocity and $p$ the pressure. We implemented a transverse isotropic permeability field $K(\boldsymbol{x})$, which is modeled by random fields, parameterized by a set of coefficients $\boldsymbol{x}$.
+With $K$ being a $\dim \times \dim$ permeability tensor, $\boldsymbol{u}$ the flow velocity and $p$ the pressure. The isotropic permeability field $K(\boldsymbol{x}) = \exp(\boldsymbol{x}) \cdot I$ is parameterized by random field coefficients $\boldsymbol{x}$.
 
-The project builds two executables:
-1. `darcy_forward.cc` → `darcy_forward`: The main executable and forward solve of the PDE for a specific choice of random field coefficients $\boldsymbol{x}$ which imposes the mapping: $\boldsymbol{y} = f(\boldsymbol{x})$
-2. `darcy_adjoint.cc` → `darcy_adjoint`: The associated adjoint problem that returns the derivative $\frac{\partial g(f(\boldsymbol{x}))}{\partial \boldsymbol{x}}$ for an objective function $g$
+The project builds three executables:
+1. `darcy_forward`: Forward solve $\boldsymbol{y} = f(\boldsymbol{x})$ for given random field coefficients
+2. `darcy_adjoint`: Adjoint solve returning the gradient $\frac{\partial g(f(\boldsymbol{x}))}{\partial \boldsymbol{x}}$
+3. `export_sparsity`: Exports the prior precision matrix sparsity pattern and values (COO format as `.npy` files). This is needed to construct a sparse variational approximation in the stochastic variational inference (SVI) framework — the FE mesh-induced sparsity pattern of $Q$ motivates the sparsity structure of the variational precision matrix, ensuring the approximation respects the local correlation structure of the prior.
 
-## Random permeability field
-The random isotropic permeability tensor $K(\boldsymbol{x})$ is modeled as follows:
-
-$$K(\boldsymbol{x}) = \exp(\boldsymbol{x}) \cdot I$$
-
-such that $\boldsymbol{x}$ can be inferred without constraints.
+Both the forward and adjoint executables support 2D and 3D via the `spatial dimension` parameter.
 
 ## Configuration
-The executables use deal.II's `ParameterHandler` to read configuration from a JSON or PRM file.
+
+The executables use deal.II's `ParameterHandler` to read configuration from a JSON file.
 
 ### Parameters
 
 | Parameter | Section | Default | Description |
 |---|---|---|---|
+| `spatial dimension` | Discretization | 3 | Spatial dimension (2 or 3) |
 | `pressure fe degree` | Discretization | 1 | Polynomial degree for pressure FE (velocity = degree + 1) |
 | `random field fe degree` | Discretization | 2 | Polynomial degree for random field FE |
 | `refinement level` | Discretization | 4 | Global mesh refinement level |
 | `refinement level obs` | Discretization | 3 | Observation mesh refinement level |
-| `alpha` | Prior | 2 | SPDE operator power $n$: Matérn smoothness $\nu = n - d/2$. Use $n \geq 2$ for 3D |
-| `kappa squared` | Prior | 16.0 | Controls prior correlation length: $\rho = \sqrt{8\nu}/\kappa$ |
+| `nugget` | Prior | 1e-6 | Nugget for Markov prior: $Q = G + \varepsilon M$ |
+| `ground truth` | Input/Output | false | Use analytical reference field instead of reading from file |
 | `input npy file` | Input/Output | — | Path to random field coefficients (.npy) |
 | `output directory` | Input/Output | `output` | Results directory |
 | `output prefix` | Input/Output | `""` | Filename prefix for outputs |
 | `adjoint data file` | Input/Output | `adjoint_data.npy` | Upstream gradient filename (adjoint only) |
 
-### SPDE prior parameters
+### Prior
 
-The adjoint solver uses an SPDE--GMRF prior (Lindgren, Rue & Lindström, 2011) with precision matrix $Q = z \, B_n^T M^{-1} B_n$, where $B_n = A_\kappa (M^{-1} A_\kappa)^{n-1}$ and $A_\kappa = \kappa^2 M + G$. The key parameters are:
-- **`alpha`** ($n$): SPDE operator power. Determines Matérn smoothness $\nu = n - d/2$. In 3D, $n=2$ gives $\nu=1/2$ (continuous paths), $n=3$ gives $\nu=3/2$ (differentiable). Must be $\geq 2$ for valid 3D fields.
-- **`kappa squared`** ($\kappa^2$): Controls the practical correlation length $\rho = \sqrt{8\nu}/\kappa$. Examples for $n=2$ ($\nu=0.5$) on the donut domain (outer radius 1.0):
+The adjoint solver uses a Markov prior with precision matrix $Q = G + \varepsilon M$, where $G$ is the stiffness (Laplacian) matrix, $M$ the mass matrix, and $\varepsilon$ the nugget term. The precision scaling $z$ is updated adaptively via a conjugate Gamma hyper-prior (Student-t-like behavior):
 
-  | $\kappa^2$ | $\rho$ | Interpretation |
-  |---|---|---|
-  | 4.0 | 1.0 | Full domain extent |
-  | 16.0 | 0.5 | Half the outer radius |
-  | 64.0 | 0.25 | Local features |
+$$z = \frac{a_0 + n/2}{b_0 + \frac{1}{2}(\boldsymbol{x} - \boldsymbol{\mu})^T Q (\boldsymbol{x} - \boldsymbol{\mu})}$$
 
 ### Example JSON configuration
 
 ```json
 {
   "Discretization": {
+    "spatial dimension": 3,
     "pressure fe degree": 1,
     "random field fe degree": 2,
     "refinement level": 4,
     "refinement level obs": 3
   },
   "Prior": {
-    "alpha": 2,
-    "kappa squared": 16.0
+    "nugget": 1.0e-4
   },
   "Input/Output": {
-    "input npy file": "input/markov_field_5.npy",
+    "ground truth": false,
+    "input npy file": "input/coefficients.npy",
     "output directory": "output",
     "output prefix": "my_sim_",
     "adjoint data file": "adjoint_data.npy"
@@ -77,22 +70,36 @@ The adjoint solver uses an SPDE--GMRF prior (Lindgren, Rue & Lindström, 2011) w
 ```
 
 ## Running the executables
-The primary problem can be started with:
+
+The forward problem:
 ```bash
 mpirun -np <num_procs> darcy_forward parameters.json
 ```
 
-The associated adjoint problem:
+The adjoint problem:
 ```bash
 mpirun -np <num_procs> darcy_adjoint parameters.json
 ```
 
-Note: The `adjoint_data.npy` file should be located in the same directory as the input npy file specified in the parameter file.
+The adjoint requires the forward solution (`*_solution_full.npy`) and an upstream gradient file (`adjoint_data.npy` in the same directory as `input npy file`).
 
 ## Setup, installation and dependencies
 
-This code requires the installation and setup of [deal.II](https://www.dealii.org/), furthermore, the [Trilinos](https://trilinos.github.io/) project needs to be configured and installed. For parallel computing, respectively partitioning we furthermore require the installation of 
-[p4est](pymc.io/projects/examples/en/latest/gallery.html). 
+This code requires:
+- [deal.II](https://www.dealii.org/) >= 9.5.0 (with Trilinos and p4est enabled)
+- [Trilinos](https://trilinos.github.io/)
+- [p4est](https://www.p4est.org/) for parallel mesh partitioning
+- MPI
+
+### Building
+
+The project uses out-of-source CMake builds:
+
+```bash
+mkdir -p build/release && cd build/release
+cmake -DDEAL_II_DIR=/path/to/dealii-install -DCMAKE_BUILD_TYPE=Release ../..
+make -j$(nproc)
+```
 
 ## Associated deal.II tutorials
 

--- a/darcy_adjoint.cc
+++ b/darcy_adjoint.cc
@@ -4,7 +4,8 @@
 
 #include "parameters.h"
 
-// Explicit template instantiation
+// Explicit template instantiations
+template class darcy::DarcyAdjoint<2>;
 template class darcy::DarcyAdjoint<3>;
 
 // ---------------------- main function adjoint -----------------------------
@@ -50,9 +51,19 @@ main(int argc, char *argv[])
       // Create output directory if it doesn't exist
       std::filesystem::create_directories(params.output_directory);
 
-      // Run adjoint solver
-      DarcyAdjoint<3> mixed_laplace_problem(params.fe_degree, params.degree_rf);
-      mixed_laplace_problem.run(params);
+      // Run adjoint solver (dispatch on spatial dimension)
+      if (params.spatial_dimension == 2)
+        {
+          DarcyAdjoint<2> mixed_laplace_problem(params.fe_degree,
+                                                params.degree_rf);
+          mixed_laplace_problem.run(params);
+        }
+      else
+        {
+          DarcyAdjoint<3> mixed_laplace_problem(params.fe_degree,
+                                                params.degree_rf);
+          mixed_laplace_problem.run(params);
+        }
     }
   catch (std::exception &exc)
     {

--- a/darcy_adjoint.h
+++ b/darcy_adjoint.h
@@ -471,55 +471,20 @@ namespace darcy
                                       coefficient,
                                       rf_constraints);
 
-    // L = G + kappa^2 * M (SPDE precision operator).
-    // kappa^2 controls the correlation length: rho = sqrt(8*nu) / kappa.
-    const double kappa_squared = this->params.kappa_squared;
-    this->pcout << "  kappa^2 = " << kappa_squared << std::endl;
-    this->rf_laplace_matrix.add(kappa_squared, rf_mass_matrix);
+    // Markov prior: Q = G + nugget * M
+    const double nugget = this->params.nugget;
+    this->pcout << "  Prior nugget = " << nugget << std::endl;
+    this->rf_laplace_matrix.add(nugget, rf_mass_matrix);
   }
 
   template <int dim>
   void
   DarcyAdjoint<dim>::add_prior_gradient_to_adjoint()
   {
-    // SPDE--GMRF prior with precision matrix (Lindgren, Rue & Lindstroem,
-    // 2011):
-    //   Q_SPDE = z * B_n^T * M^{-1} * B_n
-    // where B_n = A_kappa * (M^{-1} * A_kappa)^{n-1},
-    //       A_kappa = kappa^2 * M + G  (stiffness + scaled mass matrix),
-    //       n = alpha (SPDE operator power).
-    //
-    // Matern smoothness: nu = n - dim/2.
-    //   n=2, dim=3 -> nu=0.5 (continuous), n=3 -> nu=1.5 (differentiable)
-    //
-    // The gradient of the log-prior is:
-    //   nabla_x log p(x) = -z * B_n^T * M^{-1} * B_n * (x - mu)
-    // computed via:
-    //   1. Forward cascade:  w = B_n * (x - mu)        [n A_kappa, n-1
-    //   M-solves]
-    //   2. Middle solve:     u = M^{-1} * w             [1 M-solve]
-    //   3. Reverse cascade:  g = B_n^T * u              [n A_kappa, n-1
-    //   M-solves]
-    // Total: 2n sparse matvecs, 2n-1 mass solves.
-    //
-    // Hierarchical z update (conjugate Gamma hyper-prior z ~ Gamma(a0, b0)):
-    //   z = (a0 + n_dofs/2) / (b0 + 0.5 * w^T * u)
-    const unsigned int n = this->params.alpha;
-
-    this->pcout << "  SPDE prior: n=" << n << ", dim=" << dim
-                << ", nu=" << n - dim / 2.0 << std::endl;
-
-    const double a0 = 1e-9;
-    const double b0 = 1e-9;
-    const double a  = a0 + this->rf_dof_handler.n_dofs() / 2.0;
-
     const IndexSet &owned = this->rf_dof_handler.locally_owned_dofs();
-    TrilinosWrappers::MPI::Vector x_minus_mean, w, u, grad, temp;
+    TrilinosWrappers::MPI::Vector x_minus_mean, grad;
     x_minus_mean.reinit(owned, MPI_COMM_WORLD);
-    w.reinit(owned, MPI_COMM_WORLD);
-    u.reinit(owned, MPI_COMM_WORLD);
     grad.reinit(owned, MPI_COMM_WORLD);
-    temp.reinit(owned, MPI_COMM_WORLD);
 
     for (const auto idx : owned)
       x_minus_mean[idx] = this->x_vec_distributed[idx];
@@ -527,65 +492,24 @@ namespace darcy
 
     x_minus_mean.add(-1.0, this->mean_rf);
 
-    TrilinosWrappers::PreconditionJacobi mass_preconditioner;
-    mass_preconditioner.initialize(rf_mass_matrix);
+    // Markov prior: Q = G + nugget * M
+    //   grad log p(x) = -z * Q * (x - mu)
+    //   z = (a0 + n_dofs/2) / (b0 + q/2)  with q = (x-mu)^T Q (x-mu)
+    this->pcout << "  Markov prior (Laplacian + nugget)" << std::endl;
 
-    // -------------------------------------------------------------------
-    // Forward cascade: w = B_n * (x - mu)
-    //   B_n = A_kappa * (M^{-1} * A_kappa)^{n-1}
-    // -------------------------------------------------------------------
-    w = x_minus_mean;
-    for (unsigned int i = 0; i < n - 1; ++i)
-      {
-        this->rf_laplace_matrix.vmult(temp, w);
-        SolverControl solver_control(100, 1e-10 * temp.l2_norm());
-        SolverCG<TrilinosWrappers::MPI::Vector> cg(solver_control);
-        w = 0;
-        cg.solve(rf_mass_matrix, w, temp, mass_preconditioner);
-        this->pcout << "    Forward M^{-1} solve " << i + 1 << ": "
-                    << solver_control.last_step() << " CG iterations"
-                    << std::endl;
-      }
-    this->rf_laplace_matrix.vmult(temp, w);
-    w = temp;
+    this->rf_laplace_matrix.vmult(grad, x_minus_mean);
 
-    // -------------------------------------------------------------------
-    // Middle solve: u = M^{-1} * w
-    // -------------------------------------------------------------------
-    {
-      SolverControl solver_control(100, 1e-10 * w.l2_norm());
-      SolverCG<TrilinosWrappers::MPI::Vector> cg(solver_control);
-      u = 0;
-      cg.solve(rf_mass_matrix, u, w, mass_preconditioner);
-      this->pcout << "    Middle M^{-1} solve: " << solver_control.last_step()
-                  << " CG iterations" << std::endl;
-    }
+    const double n_dofs = this->rf_dof_handler.n_dofs();
+    const double q      = x_minus_mean * grad;
 
-    // -------------------------------------------------------------------
-    // Quadratic form: q = w^T * u = (B_n(x-mu))^T M^{-1} (B_n(x-mu))
-    // -------------------------------------------------------------------
-    const double quad_form = w * u;
-    const double b         = b0 + 0.5 * quad_form;
-    const double z         = a / b;
-    this->pcout << "  Precision scaling z = " << z
-                << " (quad_form = " << quad_form << ")" << std::endl;
+    const double a0 = 1e-9;
+    const double b0 = 1e-9;
+    const double a  = a0 + n_dofs / 2.0;
+    const double b  = b0 + 0.5 * q;
+    const double z  = a / b;
 
-    // -------------------------------------------------------------------
-    // Reverse cascade: grad = B_n^T * u
-    //   B_n^T = (A_kappa * M^{-1})^{n-1} * A_kappa  (A_kappa, M symmetric)
-    // -------------------------------------------------------------------
-    this->rf_laplace_matrix.vmult(grad, u);
-    for (unsigned int i = 0; i < n - 1; ++i)
-      {
-        SolverControl solver_control(100, 1e-10 * grad.l2_norm());
-        SolverCG<TrilinosWrappers::MPI::Vector> cg(solver_control);
-        temp = 0;
-        cg.solve(rf_mass_matrix, temp, grad, mass_preconditioner);
-        this->pcout << "    Reverse M^{-1} solve " << i + 1 << ": "
-                    << solver_control.last_step() << " CG iterations"
-                    << std::endl;
-        this->rf_laplace_matrix.vmult(grad, temp);
-      }
+    this->pcout << "  Precision scaling z = " << z << " (q = " << q
+                << ", n_dofs = " << n_dofs << ")" << std::endl;
 
     grad *= -z;
 
@@ -596,7 +520,8 @@ namespace darcy
                         MPI_COMM_WORLD,
                         grad_log_lik_x);
 
-    this->pcout << "Successfully added SPDE prior gradient to adjoint gradient!"
+    this->pcout << "Successfully added Markov prior gradient to adjoint "
+                   "gradient!"
                 << std::endl;
   }
 
@@ -627,7 +552,7 @@ namespace darcy
     data_out.add_data_vector(gradient_distributed, "gradient");
 
     MappingQ<dim> mapping(2);
-    data_out.build_patches(mapping, 2, DataOut<dim>::curved_inner_cells);
+    data_out.build_patches(mapping, 2, DataOut<dim>::curved_boundary);
 
     const std::string filename      = this->params.output_prefix + "gradient";
     const std::string stripped_path = this->params.output_directory + "/";
@@ -653,8 +578,10 @@ namespace darcy
     std::filesystem::path adjoint_data_path =
       input_path.parent_path() / this->params.adjoint_data_file;
 
+    std::vector<unsigned int> block_component(dim + 1, 0);
+    block_component[dim] = 1;
     const std::vector<types::global_dof_index> dofs_per_block =
-      DoFTools::count_dofs_per_fe_block(this->dof_handler, {0, 0, 0, 1});
+      DoFTools::count_dofs_per_fe_block(this->dof_handler, block_component);
     const types::global_dof_index n_u = dofs_per_block[0],
                                   n_p = dofs_per_block[1];
     std::vector<IndexSet> partitioning;
@@ -673,13 +600,15 @@ namespace darcy
                                         relevant_partitioning,
                                         MPI_COMM_WORLD);
 
-    this->read_input_npy();
+    if (this->params.ground_truth)
+      this->generate_ref_input();
+    else
+      this->read_input_npy();
     this->generate_coordinates();
     setup_point_evaluation_cache(); // Cache RPE for efficient RHS assembly
     read_upstream_gradient_npy(adjoint_data_path.string());
     read_primary_solution();
-    this->assemble_approx_schur_complement();
-    this->assemble_system();
+    this->assemble_system_and_schur();
     overwrite_adjoint_rhs();
     this->solve(adjoint_solve);
     final_inner_adjoint_product();
@@ -731,7 +660,7 @@ namespace darcy
     MappingQ<dim> mapping(2);
     data_out.build_patches(mapping,
                            this->degree_u,
-                           DataOut<dim>::curved_inner_cells);
+                           DataOut<dim>::curved_boundary);
 
     const std::string filename =
       this->params.output_prefix + "adjoint_solution";

--- a/darcy_base.h
+++ b/darcy_base.h
@@ -126,6 +126,8 @@ namespace darcy
     assemble_system(); // Assemble Darcy saddle-point system
     void
     assemble_approx_schur_complement(); // Assemble preconditioner matrix
+    void
+    assemble_system_and_schur(); // Merged assembly of both matrices
 
     // -------------------------------------------------------------------------
     // Solver
@@ -630,6 +632,229 @@ namespace darcy
 
   template <int dim>
   void
+  DarcyBase<dim>::assemble_system_and_schur()
+  {
+    TimerOutput::Scope timer_section(this->computing_timer,
+                                     "  Assemble system + Schur");
+    this->pcout << "Assemble system and Schur complement (merged)..."
+                << std::endl;
+
+    this->system_matrix       = 0;
+    this->system_rhs          = 0;
+    this->precondition_matrix = 0;
+
+    const QGauss<dim>     quadrature_formula(this->degree_u + 1);
+    const QGauss<dim - 1> face_quadrature_formula(this->degree_u + 1);
+
+    const MappingQ<dim> mapping(2);
+
+    FEValues<dim>     fe_values(mapping,
+                            this->fe,
+                            quadrature_formula,
+                            update_values | update_quadrature_points |
+                              update_JxW_values | update_gradients);
+    FEValues<dim>     fe_rf_values(mapping,
+                               this->rf_fe_system,
+                               quadrature_formula,
+                               update_values | update_quadrature_points);
+    FEFaceValues<dim> fe_face_values(mapping,
+                                     this->fe,
+                                     face_quadrature_formula,
+                                     update_values | update_gradients |
+                                       update_normal_vectors |
+                                       update_quadrature_points |
+                                       update_JxW_values);
+
+    const unsigned int dofs_per_cell   = this->fe.n_dofs_per_cell();
+    const unsigned int n_q_points      = quadrature_formula.size();
+    const unsigned int n_face_q_points = face_quadrature_formula.size();
+
+    std::vector<Tensor<1, dim>>          phi_u(dofs_per_cell);
+    std::vector<double>                  div_phi_u(dofs_per_cell);
+    std::vector<double>                  phi_p(dofs_per_cell);
+    std::vector<Tensor<1, dim>>          grad_phi_p(dofs_per_cell);
+    std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);
+    FullMatrix<double> local_matrix(dofs_per_cell, dofs_per_cell);
+    FullMatrix<double> local_precond_matrix(dofs_per_cell, dofs_per_cell);
+    Vector<double>     local_rhs(dofs_per_cell);
+
+    this->x_vec_distributed = this->x_vec;
+
+    for (const auto &cell_tria : this->triangulation.active_cell_iterators())
+      {
+        const auto &cell =
+          cell_tria->as_dof_handler_iterator(this->dof_handler);
+        const auto &rf_cell =
+          cell_tria->as_dof_handler_iterator(this->rf_dof_handler);
+
+        if (cell->is_locally_owned())
+          {
+            fe_values.reinit(cell);
+            fe_rf_values.reinit(rf_cell);
+            cell->get_dof_indices(local_dof_indices);
+
+            const FEValuesExtractors::Vector velocities(0);
+            const FEValuesExtractors::Scalar pressure(dim);
+
+            local_matrix         = 0;
+            local_precond_matrix = 0;
+            local_rhs            = 0;
+
+            std::vector<double> boundary_values_pressure(n_face_q_points);
+            const PressureBoundaryValues<dim> pressure_boundary_values;
+
+            std::vector<double> rf_values(n_q_points);
+            Tensor<2, dim>      K_mat;
+            fe_rf_values.get_function_values(this->x_vec_distributed,
+                                             rf_values);
+
+            for (unsigned int q = 0; q < n_q_points; ++q)
+              {
+                RandomMedium::get_k_mat(rf_values[q], K_mat);
+                const Tensor<2, dim> k_inverse = invert(K_mat);
+
+                for (unsigned int k = 0; k < dofs_per_cell; ++k)
+                  {
+                    phi_u[k]      = fe_values[velocities].value(k, q);
+                    div_phi_u[k]  = fe_values[velocities].divergence(k, q);
+                    phi_p[k]      = fe_values[pressure].value(k, q);
+                    grad_phi_p[k] = fe_values[pressure].gradient(k, q);
+                  }
+
+                const auto JxW_q = fe_values.JxW(q);
+
+                // System matrix assembly
+                for (unsigned int i = 0; i < dofs_per_cell; ++i)
+                  {
+                    for (unsigned int j = 0; j < dofs_per_cell; ++j)
+                      {
+                        local_matrix(i, j) +=
+                          (phi_u[i] * k_inverse * phi_u[j] -
+                           phi_p[j] * div_phi_u[i] + grad_phi_p[i] * phi_u[j]) *
+                          JxW_q;
+                      }
+
+                    local_rhs(i) += (-phi_p[i] * 1.0) * JxW_q;
+                  }
+
+                // Schur complement assembly (pressure-pressure block)
+                for (unsigned int i = 0; i < dofs_per_cell; ++i)
+                  for (unsigned int j = 0; j <= i; ++j)
+                    local_precond_matrix(i, j) +=
+                      (K_mat * grad_phi_p[i] * grad_phi_p[j]) * JxW_q;
+              }
+
+            // Symmetrize Schur complement local matrix
+            for (unsigned int i = 0; i < dofs_per_cell; ++i)
+              for (unsigned int j = i + 1; j < dofs_per_cell; ++j)
+                local_precond_matrix(i, j) = local_precond_matrix(j, i);
+
+            // Face integrals
+            for (const auto &face : cell->face_iterators())
+              {
+                if (face->at_boundary() && face->boundary_id() == 1)
+                  {
+                    fe_face_values.reinit(cell, face);
+
+                    pressure_boundary_values.value_list(
+                      fe_face_values.get_quadrature_points(),
+                      boundary_values_pressure);
+
+                    const auto tau =
+                      5. * Utilities::fixed_power<2>(this->degree_p + 1) /
+                      cell->diameter();
+
+                    for (unsigned int q = 0; q < n_face_q_points; ++q)
+                      {
+                        const auto normal = fe_face_values.normal_vector(q);
+
+                        for (unsigned int i = 0; i < dofs_per_cell; ++i)
+                          {
+                            const Tensor<1, dim> phi_i_u =
+                              fe_face_values[velocities].value(i, q);
+                            const double phi_i_p =
+                              fe_face_values[pressure].value(i, q);
+                            const auto grad_phi_i_p =
+                              fe_face_values[pressure].gradient(i, q);
+
+                            // System RHS boundary term
+                            local_rhs(i) +=
+                              -(phi_i_u * normal * boundary_values_pressure[q] *
+                                fe_face_values.JxW(q));
+
+                            for (unsigned int j = 0; j < dofs_per_cell; ++j)
+                              {
+                                const Tensor<1, dim> phi_j_u =
+                                  fe_face_values[velocities].value(j, q);
+                                const double phi_j_p =
+                                  fe_face_values[pressure].value(j, q);
+                                const auto grad_phi_j_p =
+                                  fe_face_values[pressure].gradient(j, q);
+
+                                // System matrix boundary term
+                                local_matrix(i, j) -=
+                                  (phi_i_p * (normal * phi_j_u)) *
+                                  fe_face_values.JxW(q);
+
+                                // Schur complement Nitsche boundary term
+                                local_precond_matrix(i, j) +=
+                                  (-grad_phi_i_p * normal * phi_j_p -
+                                   (phi_i_p *
+                                    (grad_phi_j_p * normal - tau * phi_j_p))) *
+                                  fe_face_values.JxW(q);
+                              }
+                          }
+                      }
+                  }
+
+                if (face->at_boundary() && face->boundary_id() == 0)
+                  {
+                    fe_face_values.reinit(cell, face);
+
+                    for (unsigned int q = 0; q < n_face_q_points; ++q)
+                      {
+                        for (unsigned int i = 0; i < dofs_per_cell; ++i)
+                          {
+                            const Tensor<1, dim> phi_i_u =
+                              fe_face_values[velocities].value(i, q);
+
+                            for (unsigned int j = 0; j < dofs_per_cell; ++j)
+                              {
+                                const double phi_j_p =
+                                  fe_face_values[pressure].value(j, q);
+
+                                local_matrix(i, j) +=
+                                  (phi_j_p *
+                                   (phi_i_u * fe_face_values.normal_vector(q)) *
+                                   fe_face_values.JxW(q));
+                              }
+                          }
+                      }
+                  }
+              }
+
+            this->constraints.distribute_local_to_global(local_matrix,
+                                                         local_rhs,
+                                                         local_dof_indices,
+                                                         this->system_matrix,
+                                                         this->system_rhs);
+            this->preconditioner_constraints.distribute_local_to_global(
+              local_precond_matrix,
+              local_dof_indices,
+              this->precondition_matrix);
+          }
+      }
+
+    this->system_matrix.compress(VectorOperation::add);
+    this->system_rhs.compress(VectorOperation::add);
+    this->precondition_matrix.compress(VectorOperation::add);
+
+    this->pcout << "System and Schur complement successfully assembled"
+                << std::endl;
+  }
+
+  template <int dim>
+  void
   DarcyBase<dim>::setup_system_matrix(
     const std::vector<IndexSet> &partitioning,
     const std::vector<IndexSet> &relevant_partitioning)
@@ -864,42 +1089,53 @@ namespace darcy
     const auto        &M    = this->system_matrix.block(0, 0);
     const auto        &ap_S = this->precondition_matrix.block(1, 1);
 
-    TrilinosWrappers::PreconditionIC ap_M_inv;
-    ap_M_inv.initialize(M);
+    TrilinosWrappers::PreconditionAMG ap_M_inv;
+    {
+      TrilinosWrappers::PreconditionAMG::AdditionalData amg_data_M;
+      amg_data_M.elliptic              = true;
+      amg_data_M.higher_order_elements = true;
+      amg_data_M.smoother_sweeps       = 2;
+      amg_data_M.aggregation_threshold = 0.02;
+      ap_M_inv.initialize(M, amg_data_M);
+    }
 
-    TrilinosWrappers::PreconditionIC ap_S_inv;
-    ap_S_inv.initialize(ap_S);
-    const Preconditioner::InverseMatrix<TrilinosWrappers::SparseMatrix,
-                                        decltype(ap_S_inv)>
-      op_S_inv(ap_S, ap_S_inv);
+    TrilinosWrappers::PreconditionAMG ap_S_inv;
+    {
+      TrilinosWrappers::PreconditionAMG::AdditionalData amg_data_S;
+      amg_data_S.elliptic              = true;
+      amg_data_S.higher_order_elements = true;
+      amg_data_S.smoother_sweeps       = 2;
+      amg_data_S.aggregation_threshold = 0.02;
+      ap_S_inv.initialize(ap_S, amg_data_S);
+    }
 
-    const Preconditioner::BlockSchurPreconditioner<decltype(op_S_inv),
+    const Preconditioner::BlockSchurPreconditioner<decltype(ap_S_inv),
                                                    decltype(ap_M_inv)>
       block_preconditioner(this->system_matrix,
-                           op_S_inv,
+                           ap_S_inv,
                            ap_M_inv,
                            this->computing_timer);
     this->pcout << "Block preconditioner for the system matrix created."
                 << std::endl;
 
     const double rhs_norm      = this->system_rhs.l2_norm();
-    const double abs_tol       = 1.e-14;
-    const double rel_reduction = 1.e-12;
+    const double rel_reduction = 1.e-6;
 
-    this->pcout << "Solver: abs_tol=" << abs_tol
-                << ", rel_reduction=" << rel_reduction
+    this->pcout << "Solver: rel_reduction=" << rel_reduction
                 << ", RHS norm=" << rhs_norm << std::endl;
 
-    SolverControl solver_control_system(this->system_matrix.m(),
-                                        1.0e-10 * this->system_rhs.l2_norm(),
-                                        true,
-                                        true);
+    ReductionControl solver_control_system(this->system_matrix.m(),
+                                           1e-12,
+                                           rel_reduction);
     solver_control_system.enable_history_data();
     solver_control_system.log_history(true);
     solver_control_system.log_result(true);
-    SolverGMRES<TrilinosWrappers::MPI::BlockVector> solver_system(
-      solver_control_system,
-      SolverGMRES<TrilinosWrappers::MPI::BlockVector>::AdditionalData(200));
+    SolverGMRES<TrilinosWrappers::MPI::BlockVector>
+      solver_system(
+        solver_control_system,
+        SolverGMRES<TrilinosWrappers::MPI::BlockVector>::AdditionalData(200,
+                                                                        true, /* right preconditioning */
+                                                                        true /* use Arnoldi residual estimate (avoids extra matvec per iter) */));
 
     this->solution = 0;
 

--- a/darcy_forward.cc
+++ b/darcy_forward.cc
@@ -4,7 +4,8 @@
 
 #include "parameters.h"
 
-// Explicit template instantiation
+// Explicit template instantiations
+template class darcy::DarcyForward<2>;
 template class darcy::DarcyForward<3>;
 
 // ----------------- main -----------------
@@ -54,9 +55,19 @@ main(int argc, char *argv[])
       // Create output directory if it doesn't exist
       std::filesystem::create_directories(params.output_directory);
 
-      // Run forward solver
-      DarcyForward<3> mixed_laplace_problem(params.fe_degree, params.degree_rf);
-      mixed_laplace_problem.run(params);
+      // Run forward solver (dispatch on spatial dimension)
+      if (params.spatial_dimension == 2)
+        {
+          DarcyForward<2> mixed_laplace_problem(params.fe_degree,
+                                                params.degree_rf);
+          mixed_laplace_problem.run(params);
+        }
+      else
+        {
+          DarcyForward<3> mixed_laplace_problem(params.fe_degree,
+                                                params.degree_rf);
+          mixed_laplace_problem.run(params);
+        }
     }
   catch (std::exception &exc)
     {

--- a/darcy_forward.h
+++ b/darcy_forward.h
@@ -338,7 +338,7 @@ namespace darcy
     MappingQ<dim> mapping(2); // nonlinear mapping
     data_out.build_patches(mapping,
                            this->degree_u,
-                           DataOut<dim>::curved_inner_cells);
+                           DataOut<dim>::curved_boundary);
 
     constexpr unsigned int n_digits_counter = 2;
     constexpr unsigned int cycle = 0; // a counter for iterative output
@@ -382,7 +382,7 @@ namespace darcy
     // NOTE: In ParaView, keep "Nonlinear Subdivision Level" at 0 to avoid
     // artifacts - ParaView's subdivision algorithm doesn't match FEM
     // interpolation.
-    data_out_rf.build_patches(mapping, 2, DataOut<dim>::curved_inner_cells);
+    data_out_rf.build_patches(mapping, 2, DataOut<dim>::curved_boundary);
     data_out_rf.write_vtu_with_pvtu_record(
       stripped_path_rf, filename_rf, cycle, MPI_COMM_WORLD, n_digits_counter);
   }
@@ -408,11 +408,13 @@ namespace darcy
   DarcyForward<dim>::run_simulation()
   {
     this->setup_grid_and_dofs();
-    this->read_input_npy();
-    // this->generate_ref_input(); // TODO: should be removed in production
+    if (this->params.ground_truth)
+      this->generate_ref_input();
+    else
+      this->read_input_npy();
+
     this->generate_coordinates();
-    this->assemble_approx_schur_complement();
-    this->assemble_system();
+    this->assemble_system_and_schur();
     this->solve();
 
     // Copy solution to ghosted vector for output

--- a/export_sparsity.cc
+++ b/export_sparsity.cc
@@ -1,0 +1,297 @@
+// export_sparsity.cc
+// MPI-parallel executable to export the lower-triangular sparsity pattern
+// of the random field DOF handler as NumPy COO index files.
+//
+// IMPORTANT: Must be run with the SAME number of MPI ranks as the solver
+// (darcy_forward / darcy_adjoint) to ensure identical DOF numbering.
+// The DOF ordering depends on the p4est partitioning and Cuthill-McKee
+// renumbering, both of which change with the number of MPI ranks.
+//
+// Usage: mpirun -np <num_procs> ./export_sparsity <parameter_file.json>
+//
+// Output:
+//   rf_sparsity_row_idx.npy  (shape: [nnz, 1], double)
+//   rf_sparsity_col_idx.npy  (shape: [nnz, 1], double)
+//   rf_A_kappa_values.npy    (shape: [nnz, 1], double)
+//
+// These files are written to the current working directory.
+
+#include <deal.II/base/conditional_ostream.h>
+#include <deal.II/base/quadrature_lib.h>
+#include <deal.II/base/utilities.h>
+#include <deal.II/distributed/tria.h>
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/dofs/dof_renumbering.h>
+#include <deal.II/dofs/dof_tools.h>
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/fe_system.h>
+#include <deal.II/fe/mapping_q.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/lac/affine_constraints.h>
+#include <deal.II/lac/dynamic_sparsity_pattern.h>
+#include <deal.II/lac/sparsity_tools.h>
+#include <deal.II/lac/trilinos_sparse_matrix.h>
+#include <deal.II/lac/trilinos_sparsity_pattern.h>
+#include <deal.II/numerics/matrix_tools.h>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "npy.hpp"
+#include "parameters.h"
+
+using namespace dealii;
+
+template <int dim>
+void
+run_export_sparsity(const darcy::Parameters &params)
+{
+  const unsigned int this_mpi_process =
+    Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
+  const unsigned int n_mpi_processes =
+    Utilities::MPI::n_mpi_processes(MPI_COMM_WORLD);
+
+  ConditionalOStream pcout(std::cout, (this_mpi_process == 0));
+
+  // Build mesh (same geometry as DarcyBase::setup_grid_and_dofs)
+  parallel::distributed::Triangulation<dim> triangulation(
+    MPI_COMM_WORLD,
+    typename Triangulation<dim>::MeshSmoothing(
+      Triangulation<dim>::smoothing_on_refinement |
+      Triangulation<dim>::smoothing_on_coarsening));
+
+  Point<dim> inner_center;
+  Point<dim> outer_center;
+  if constexpr (dim == 2)
+    {
+      inner_center = Point<dim>(0.0, 0.1);
+      outer_center = Point<dim>(0.0, 0.0);
+    }
+  else if constexpr (dim == 3)
+    {
+      inner_center = Point<dim>(0.0, 0.1, 0.25);
+      outer_center = Point<dim>(0.0, 0.0, 0.0);
+    }
+
+  double       inner_radius = 0.3;
+  double       outer_radius = 1.0;
+  unsigned int n_cells      = 12;
+
+  GridGenerator::eccentric_hyper_shell(triangulation,
+                                       inner_center,
+                                       outer_center,
+                                       inner_radius,
+                                       outer_radius,
+                                       n_cells);
+  triangulation.refine_global(params.refinement_level);
+
+  // Setup random field DOF handler (same as DarcyBase)
+  FESystem<dim>   rf_fe_system(FE_Q<dim>(params.degree_rf), 1);
+  DoFHandler<dim> rf_dof_handler(triangulation);
+  rf_dof_handler.distribute_dofs(rf_fe_system);
+  DoFRenumbering::Cuthill_McKee(rf_dof_handler);
+
+  const types::global_dof_index n_dofs = rf_dof_handler.n_dofs();
+  const IndexSet locally_owned         = rf_dof_handler.locally_owned_dofs();
+  const IndexSet locally_relevant =
+    DoFTools::extract_locally_relevant_dofs(rf_dof_handler);
+
+  pcout << "Number of random field DOFs: " << n_dofs << std::endl;
+  pcout << "Number of MPI processes: " << n_mpi_processes << std::endl;
+
+  // Build sparsity pattern from FE mesh connectivity.
+  // Each rank adds entries from its own cells, then
+  // distribute_sparsity_pattern communicates ghost-row entries to the
+  // owning rank for completeness.
+  AffineConstraints<double> rf_constraints;
+  rf_constraints.close();
+
+  DynamicSparsityPattern dsp(n_dofs, n_dofs, locally_relevant);
+  DoFTools::make_sparsity_pattern(
+    rf_dof_handler, dsp, rf_constraints, false, this_mpi_process);
+  SparsityTools::distribute_sparsity_pattern(dsp,
+                                             locally_owned,
+                                             MPI_COMM_WORLD,
+                                             locally_relevant);
+
+  // Assemble A_kappa = G + kappa^2 * M (SPDE precision operator)
+  // mirroring DarcyAdjoint::create_rf_laplace_operator()
+  TrilinosWrappers::SparsityPattern sp_rf(locally_owned,
+                                          locally_owned,
+                                          locally_relevant,
+                                          MPI_COMM_WORLD);
+  DoFTools::make_sparsity_pattern(
+    rf_dof_handler, sp_rf, rf_constraints, false, this_mpi_process);
+  sp_rf.compress();
+
+  TrilinosWrappers::SparseMatrix rf_laplace_matrix;
+  rf_laplace_matrix.reinit(sp_rf);
+
+  TrilinosWrappers::SparseMatrix rf_mass_matrix;
+  rf_mass_matrix.reinit(sp_rf);
+
+  const QGauss<dim>            quadrature(params.fe_degree + 2);
+  const MappingQ<dim>          mapping(2);
+  const Function<dim, double> *coefficient = nullptr;
+
+  MatrixCreator::create_laplace_matrix(mapping,
+                                       rf_dof_handler,
+                                       quadrature,
+                                       rf_laplace_matrix,
+                                       coefficient,
+                                       rf_constraints);
+
+  MatrixCreator::create_mass_matrix(mapping,
+                                    rf_dof_handler,
+                                    quadrature,
+                                    rf_mass_matrix,
+                                    coefficient,
+                                    rf_constraints);
+
+  // Build prior precision operator: Q = G + nugget * M
+  const double nugget = params.nugget;
+  rf_laplace_matrix.add(nugget, rf_mass_matrix);
+  pcout << "Assembled Q = G + " << nugget << " * M" << std::endl;
+
+  // Extract lower-triangular COO entries and A_kappa values for locally
+  // owned rows (each DOF is owned by exactly one rank, so no duplicates)
+  std::vector<double> local_row_idx;
+  std::vector<double> local_col_idx;
+  std::vector<double> local_values;
+
+  for (const auto row : locally_owned)
+    {
+      for (auto it = dsp.begin(row); it != dsp.end(row); ++it)
+        {
+          if (it->column() <= row)
+            {
+              local_row_idx.push_back(static_cast<double>(row));
+              local_col_idx.push_back(static_cast<double>(it->column()));
+              local_values.push_back(rf_laplace_matrix.el(row, it->column()));
+            }
+        }
+    }
+
+  // Gather entry counts from all ranks onto rank 0
+  int              local_nnz = static_cast<int>(local_row_idx.size());
+  std::vector<int> all_nnz(n_mpi_processes);
+  MPI_Gather(
+    &local_nnz, 1, MPI_INT, all_nnz.data(), 1, MPI_INT, 0, MPI_COMM_WORLD);
+
+  // Compute displacements and total count on rank 0
+  std::vector<int> displs(n_mpi_processes, 0);
+  int              total_nnz = 0;
+  if (this_mpi_process == 0)
+    for (unsigned int i = 0; i < n_mpi_processes; ++i)
+      {
+        displs[i] = total_nnz;
+        total_nnz += all_nnz[i];
+      }
+
+  // Gather all COO entries and values onto rank 0
+  std::vector<double> global_row_idx(this_mpi_process == 0 ? total_nnz : 0);
+  std::vector<double> global_col_idx(this_mpi_process == 0 ? total_nnz : 0);
+  std::vector<double> global_values(this_mpi_process == 0 ? total_nnz : 0);
+
+  MPI_Gatherv(local_row_idx.data(),
+              local_nnz,
+              MPI_DOUBLE,
+              global_row_idx.data(),
+              all_nnz.data(),
+              displs.data(),
+              MPI_DOUBLE,
+              0,
+              MPI_COMM_WORLD);
+
+  MPI_Gatherv(local_col_idx.data(),
+              local_nnz,
+              MPI_DOUBLE,
+              global_col_idx.data(),
+              all_nnz.data(),
+              displs.data(),
+              MPI_DOUBLE,
+              0,
+              MPI_COMM_WORLD);
+
+  MPI_Gatherv(local_values.data(),
+              local_nnz,
+              MPI_DOUBLE,
+              global_values.data(),
+              all_nnz.data(),
+              displs.data(),
+              MPI_DOUBLE,
+              0,
+              MPI_COMM_WORLD);
+
+  // Write COO indices and A_kappa values as npy files (rank 0 only)
+  if (this_mpi_process == 0)
+    {
+      const auto nnz = static_cast<unsigned long>(total_nnz);
+      const std::vector<long unsigned> shape{nnz, 1};
+      const bool                       fortran_order = false;
+
+      npy::SaveArrayAsNumpy("rf_sparsity_row_idx.npy",
+                            fortran_order,
+                            shape.size(),
+                            shape.data(),
+                            global_row_idx);
+
+      npy::SaveArrayAsNumpy("rf_sparsity_col_idx.npy",
+                            fortran_order,
+                            shape.size(),
+                            shape.data(),
+                            global_col_idx);
+
+      npy::SaveArrayAsNumpy("rf_A_kappa_values.npy",
+                            fortran_order,
+                            shape.size(),
+                            shape.data(),
+                            global_values);
+
+      pcout << "Number of lower-triangular nonzeros: " << total_nnz
+            << std::endl;
+      pcout << "Average entries per row: "
+            << static_cast<double>(total_nnz) / n_dofs << std::endl;
+      pcout << "Wrote rf_sparsity_row_idx.npy, rf_sparsity_col_idx.npy, "
+               "and rf_A_kappa_values.npy"
+            << std::endl;
+    }
+}
+
+int
+main(int argc, char *argv[])
+{
+  try
+    {
+      if (argc != 2)
+        {
+          std::cerr << "Usage: " << argv[0] << " <parameter_file.json>"
+                    << std::endl;
+          return 1;
+        }
+
+      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+
+      // Parse parameters
+      ParameterHandler  prm;
+      darcy::Parameters params;
+      darcy::Parameters::declare_parameters(prm);
+      prm.parse_input(argv[1]);
+      params.parse_parameters(prm);
+
+      // Dispatch on spatial dimension
+      if (params.spatial_dimension == 2)
+        run_export_sparsity<2>(params);
+      else
+        run_export_sparsity<3>(params);
+    }
+  catch (std::exception &exc)
+    {
+      std::cerr << "Exception on processor "
+                << Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) << ": "
+                << exc.what() << std::endl;
+      return 1;
+    }
+
+  return 0;
+}

--- a/parameters.h
+++ b/parameters.h
@@ -18,16 +18,17 @@ namespace darcy
   struct Parameters
   {
     // Discretization
+    unsigned int spatial_dimension;
     unsigned int fe_degree;
     unsigned int degree_rf;
     unsigned int refinement_level;
     unsigned int refinement_level_obs;
 
     // Prior
-    unsigned int alpha;
-    double       kappa_squared;
+    double nugget;
 
     // Input/Output
+    bool        ground_truth;
     std::string input_npy_file;
     std::string output_directory;
     std::string output_prefix;
@@ -51,6 +52,11 @@ namespace darcy
   {
     prm.enter_subsection("Discretization");
     {
+      prm.declare_entry("spatial dimension",
+                        "3",
+                        Patterns::Integer(2, 3),
+                        "Spatial dimension of the problem (2 or 3)");
+
       prm.declare_entry("pressure fe degree",
                         "1",
                         Patterns::Integer(0),
@@ -76,24 +82,23 @@ namespace darcy
 
     prm.enter_subsection("Prior");
     {
-      prm.declare_entry("alpha",
-                        "1",
-                        Patterns::Integer(1, 3),
-                        "SPDE operator power n: Q = z * B_n^T M^{-1} B_n with "
-                        "B_n = A_kappa (M^{-1} A_kappa)^{n-1}. "
-                        "Matern smoothness nu = n - dim/2");
-
-      prm.declare_entry(
-        "kappa squared",
-        "1e-5",
-        Patterns::Double(0),
-        "SPDE parameter kappa^2 controlling the prior correlation length: "
-        "rho = sqrt(8*nu)/kappa. Larger values = shorter correlation length");
+      prm.declare_entry("nugget",
+                        "1e-6",
+                        Patterns::Double(0),
+                        "Nugget term for Markov prior: Q = G + nugget*M. "
+                        "Small positive value for positive-definiteness.");
     }
     prm.leave_subsection();
 
     prm.enter_subsection("Input/Output");
     {
+      prm.declare_entry(
+        "ground truth",
+        "false",
+        Patterns::Bool(),
+        "If true, use the analytical reference field (RefScalar) "
+        "instead of reading from the input npy file");
+
       prm.declare_entry("input npy file",
                         "input/markov_field_5.npy",
                         Patterns::FileName(),
@@ -126,6 +131,7 @@ namespace darcy
   {
     prm.enter_subsection("Discretization");
     {
+      spatial_dimension    = prm.get_integer("spatial dimension");
       fe_degree            = prm.get_integer("pressure fe degree");
       degree_rf            = prm.get_integer("random field fe degree");
       refinement_level     = prm.get_integer("refinement level");
@@ -135,13 +141,13 @@ namespace darcy
 
     prm.enter_subsection("Prior");
     {
-      alpha         = prm.get_integer("alpha");
-      kappa_squared = prm.get_double("kappa squared");
+      nugget = prm.get_double("nugget");
     }
     prm.leave_subsection();
 
     prm.enter_subsection("Input/Output");
     {
+      ground_truth      = prm.get_bool("ground truth");
       input_npy_file    = prm.get("input npy file");
       output_directory  = prm.get("output directory");
       output_prefix     = prm.get("output prefix");

--- a/parameters_template.json
+++ b/parameters_template.json
@@ -1,15 +1,16 @@
 {
   "Discretization": {
+    "spatial dimension": 3,
     "pressure fe degree": 1,
     "random field fe degree": 2,
     "refinement level": 4,
     "refinement level obs": 3
   },
   "Prior": {
-    "alpha": 2,
-    "kappa squared": 16.0
+    "nugget": 1.0e-4
   },
   "Input/Output": {
+    "ground truth": false,
     "input npy file": "{{ input_file_path }}",
     "output directory": "{{ output_directory }}",
     "output prefix": "{{ output_prefix }}",


### PR DESCRIPTION
Merge system and Schur complement assembly into a single cell loop to avoid duplicate FEValues reinit overhead. Switch GMRES to Arnoldi residual estimate to halve preconditioner applications per solve. Use AMG instead of IC for the block preconditioner. Together these reduce forward solve wall time by ~20%.

Remove the SPDE-GMRF prior and keep only the simpler Markov prior Q = G + nugget*M with adaptive precision scaling. Update parameter handling and template accordingly.

Add 2D dispatch in both executables via spatial_dimension parameter, export_sparsity utility for SVI variational precision parameterization, and updated README.